### PR TITLE
Fix uncommitted changes when saving occupation

### DIFF
--- a/ApartmentsAllocationHelper/OccupationWindow.xaml.cs
+++ b/ApartmentsAllocationHelper/OccupationWindow.xaml.cs
@@ -102,7 +102,10 @@ namespace ApartmentsAllocationHelper
                         _curApart.ClientId = _curClient.Id;
                         _curApart.OccupationDate = DateTime.Now;
                         _dbContext.Apartments.Update(_curApart);
-                        _dbContext.SaveChangesAsync();
+                        // SaveChangesAsync was used without awaiting which
+                        // could lead to uncommitted changes. Use synchronous
+                        // SaveChanges to ensure the update completes.
+                        _dbContext.SaveChanges();
                         MessageBox.Show("تم تأكيد العملية");
                         this.Close();
                     }


### PR DESCRIPTION
## Summary
- fix apartment occupation save by using synchronous `SaveChanges`

## Testing
- `xbuild ApartmentsAllocationHelper.sln` *(fails: missing NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_684a521d0bc883249afe124d664eb34d