### PR TITLE
Fix BackgroundWorker typos in region comments

### DIFF
--- a/ApartmentsAllocationHelper/MainForm.cs
+++ b/ApartmentsAllocationHelper/MainForm.cs
@@ -22,7 +22,7 @@ namespace ApartmentsAllocationHelper
         {
             InitializeComponent();
 
-            #region Config BackGroundWorker To Load Projects List
+            #region Config BackgroundWorker To Load Projects List
             try
             {
                 projectLoaderAgent = new BackgroundWorker();

--- a/ApartmentsAllocationHelper/ManageProjectSelection.xaml.cs
+++ b/ApartmentsAllocationHelper/ManageProjectSelection.xaml.cs
@@ -35,7 +35,7 @@ namespace ApartmentsAllocationHelper
             {
                 projectsComboBox.ItemsSource = pList;
 
-                #region Config BackGroundWorker To Load Data
+                #region Config BackgroundWorker To Load Data
                 projectDetailsLoaderAgent = new BackgroundWorker();
                 projectDetailsLoaderAgent.DoWork += ProjectDetailsLoaderAgent_DoWork;
                 projectDetailsLoaderAgent.RunWorkerCompleted += ProjectDetailsLoaderAgent_RunWorkerCompleted;


### PR DESCRIPTION
## Summary
- fix typos in region comments referring to BackgroundWorker

## Testing
- `dotnet build ApartmentsAllocationHelper.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a537a765c8324b1438c6b51529941