### PR TITLE
Initialize curId before project details load

### DIFF
--- a/ApartmentsAllocationHelper/ManageProjectSelection.xaml.cs
+++ b/ApartmentsAllocationHelper/ManageProjectSelection.xaml.cs
@@ -99,8 +99,8 @@ namespace ApartmentsAllocationHelper
                 {
                     showBtn.IsEnabled = false;
                     projectDetailsBtn.IsEnabled = false;
-                    projectDetailsLoaderAgent.RunWorkerAsync();
                     curId = projectsComboBox.SelectedValue.ToString();
+                    projectDetailsLoaderAgent.RunWorkerAsync();
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- set `curId` before kicking off `RunWorkerAsync`

## Testing
- `xbuild ApartmentsAllocationHelper.sln /t:Rebuild /p:Configuration=Release` *(fails: feature `pattern matching` not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684a537aed08832485c6871abe5608a2