### PR TITLE
Fix build workflow to skip setup project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,22 +1,22 @@
 name: .NET Framework Build
 
-on:
+'on':
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
 
-    - name: Restore NuGet packages
-      run: nuget restore ApartmentsAllocationHelper.sln
+      - name: Restore NuGet packages
+        run: nuget restore ApartmentsAllocationHelper.sln
 
-    - name: Build solution
-      run: msbuild ApartmentsAllocationHelper.sln /p:Configuration=Release /p:Platform="Any CPU"
+      - name: Build application
+        run: msbuild ApartmentsAllocationHelper/ApartmentsAllocationHelper.csproj /p:Configuration=Release /p:Platform="Any CPU"


### PR DESCRIPTION
## Summary
- fix GitHub action indentation and branch names
- build only the WPF project so the Setup project isn't required

## Testing
- `yamllint .github/workflows/main.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c2697388324aa62706919db5d74